### PR TITLE
Add restart policy for docker-compose and add update password policy for the admin account of keycloak

### DIFF
--- a/assets/js/hubsetup.js
+++ b/assets/js/hubsetup.js
@@ -380,6 +380,7 @@ EOF`;
         interval: '10s',
         timeout: '3s',
       },
+      restart: 'unless-stopped',
       environment: {
         POSTGRES_PASSWORD: this.cfg.db.adminPw,
         POSTGRES_INITDB_ARGS: '--encoding=UTF8',
@@ -410,6 +411,7 @@ EOF`;
         interval: '10s',
         timeout: '3s',
       },
+      restart: 'unless-stopped',
       environment: {
         KEYCLOAK_ADMIN: this.cfg.keycloak.adminUser,
         KEYCLOAK_ADMIN_PASSWORD: this.cfg.keycloak.adminPw,
@@ -445,6 +447,7 @@ EOF`;
         interval: '10s',
         timeout: '3s',
       },
+      restart: 'unless-stopped',
       environment: {
         HUB_KEYCLOAK_PUBLIC_URL: this.cfg.keycloak.publicUrl,
         HUB_KEYCLOAK_LOCAL_URL: !this.cfg.keycloak.useExternal ? `http://keycloak:8080${this.getPathname(this.cfg.keycloak.publicUrl)}` : this.cfg.keycloak.publicUrl,
@@ -469,7 +472,8 @@ EOF`;
       image: 'nginxproxy/nginx-proxy:alpine',
       ports: [`${this.cfg.compose.nginxProxyPort}:${!this.cfg.compose.enforceSsl ? 80 : 443}`],
       volumes: ['/var/run/docker.sock:/tmp/docker.sock:ro'],
-      ...(this.cfg.compose.enforceSsl) && { environment: { HTTP_PORT: 443 } }
+      ...(this.cfg.compose.enforceSsl) && { environment: { HTTP_PORT: 443 } },
+      restart: 'unless-stopped'
     }
   }
 

--- a/assets/js/hubsetup.js
+++ b/assets/js/hubsetup.js
@@ -239,13 +239,14 @@ GRANT ALL PRIVILEGES ON DATABASE hub TO hub;`);
         {
           username: this.cfg.hub.adminUser,
           enabled: true,
-          credentials: [{ type: 'password', value: this.cfg.hub.adminPw }],
+          credentials: [{ type: 'password', value: this.cfg.hub.adminPw, temporary: true }],
+          requiredActions: ['UPDATE_PASSWORD'],
           realmRoles: ['admin']
         },
         {
           username: this.cfg.hub.syncerUser,
           enabled: true,
-          credentials: [{ type: 'password', value: this.cfg.hub.syncerPw }],
+          credentials: [{ type: 'password', value: this.cfg.hub.syncerPw, temporary: false }],
           realmRoles: ['syncer']
         }
       ],


### PR DESCRIPTION
As discussed with @tobihagemann:

* Add restart policy for docker-compose so that they get restarted when stopped e.g. during a reboot of the host machine

* While the first login, the admin user is requested to update the password to prevent insecure systems with admin/admin combinations in the field

   ![Screenshot from 2022-07-12 16-35-55](https://user-images.githubusercontent.com/1786772/178516588-839b8320-b8de-4e32-aea6-18251278a3ef.png)
