### PR TITLE
Register Hub CE

### DIFF
--- a/assets/js/hubce.js
+++ b/assets/js/hubce.js
@@ -12,6 +12,7 @@ class HubCE {
     this._submitData = submitData;
     this._searchParams = searchParams;
     this._submitData.oldLicense = searchParams.get('oldLicense');
+    this._submitData.returnUrl = searchParams.get('returnUrl');
 
     // continue after email verified:
     if (searchParams.get('verifiedEmail')) {
@@ -66,6 +67,7 @@ class HubCE {
       data: {
         email: this._submitData.email,
         oldLicense: this._submitData.oldLicense,
+        returnUrl: this._submitData.returnUrl,
         verifyCaptcha: this._submitData.captcha,
         verifyEmail: this._submitData.email,
         verifyTarget: 'registerhubce'

--- a/assets/js/hubce.js
+++ b/assets/js/hubce.js
@@ -15,8 +15,8 @@ class HubCE {
 
     // continue after email verified:
     if (searchParams.get('verifiedEmail')) {
-      feedbackData.currentStep = 2;
-      feedbackData.success = true;
+      feedbackData.currentStep = 1;
+      feedbackData.emailVerified = true;
     }
   }
 
@@ -81,6 +81,8 @@ class HubCE {
   }
 
   getHubLicense() {
+    this._feedbackData.inProgress = true;
+    this._feedbackData.errorMessage = '';
     $.ajax({
       url: REFRESH_LICENSE_URL,
       type: 'POST',
@@ -90,6 +92,7 @@ class HubCE {
       }
     }).done(response => {
       this._feedbackData.licenseText = response;
+      this._feedbackData.inProgress = false;
     }).fail(xhr => {
       this.onRequestFailed(xhr.responseJSON?.message || 'Fetching license failed.');
     });
@@ -101,7 +104,7 @@ class HubCE {
   }
 
   onRequestSucceeded() {
-    this._feedbackData.currentStep++;
+    this._feedbackData.emailSent = true;
     this._feedbackData.inProgress = false;
     this._feedbackData.errorMessage = '';
   }

--- a/assets/js/hubce.js
+++ b/assets/js/hubce.js
@@ -2,7 +2,7 @@
 
 // requires newsletter.js
 const VERIFY_EMAIL_URL = API_BASE_URL + '/connect/email/verify';
-const GET_LICENSE_URL = API_BASE_URL + '/licenses/hub';
+const CLAIM_LICENSE_URL = API_BASE_URL + '/licenses/hub/prod';
 
 class HubCE {
 
@@ -17,6 +17,15 @@ class HubCE {
     if (searchParams.get('verifiedEmail')) {
       feedbackData.currentStep = 2;
       feedbackData.success = true;
+    }
+  }
+
+  submit() {
+    if (this._feedbackData.currentStep === 0) {
+      this.validateEmail();
+    } else if (this._feedbackData.currentStep === 1) {
+      this.sendConfirmationEmail();
+    } else if (this._feedbackData.currentStep === 2) {
       this.getHubLicense();
     }
   }
@@ -73,10 +82,11 @@ class HubCE {
 
   getHubLicense() {
     $.ajax({
-      url: GET_LICENSE_URL,
-      type: 'GET',
+      url: CLAIM_LICENSE_URL,
+      type: 'POST',
       data: {
-        hubId: this._submitData.hubId
+        hubId: this._submitData.hubId,
+        captcha: this._submitData.captcha
       }
     }).done(response => {
       this._feedbackData.licenseText = response;

--- a/assets/js/hubce.js
+++ b/assets/js/hubce.js
@@ -1,0 +1,99 @@
+"use strict";
+
+// requires newsletter.js
+const VERIFY_EMAIL_URL = API_BASE_URL + '/connect/email/verify';
+const GET_LICENSE_URL = API_BASE_URL + '/licenses/hub';
+
+class HubCE {
+
+  constructor(form, feedbackData, submitData, searchParams) {
+    this._form = form;
+    this._feedbackData = feedbackData;
+    this._submitData = submitData;
+    this._searchParams = searchParams;
+    this._submitData.hubId = searchParams.get('hubId');
+
+    // continue after email verified:
+    if (searchParams.get('verifiedEmail')) {
+      feedbackData.currentStep = 2;
+      feedbackData.success = true;
+      this.getHubLicense();
+    }
+  }
+
+  validateEmail() {
+    if (!$(this._form)[0].checkValidity()) {
+      $(this._form).find(':input').addClass('show-invalid');
+      this._feedbackData.errorMessage = 'Please fill in all required fields.';
+      return;
+    }
+    this.onValidationSucceeded();
+  }
+
+  onValidationFailed(error) {
+    this._feedbackData.inProgress = false;
+    this._feedbackData.errorMessage = error;
+  }
+
+  onValidationSucceeded() {
+    this._feedbackData.currentStep++;
+    this._feedbackData.inProgress = false;
+    this._feedbackData.errorMessage = '';
+  }
+
+  sendConfirmationEmail() {
+    if (!$(this._form)[0].checkValidity()) {
+      $(this._form).find(':input').addClass('show-invalid');
+      this._feedbackData.errorMessage = 'Please fill in all required fields.';
+      return;
+    }
+
+    this._feedbackData.success = false;
+    this._feedbackData.inProgress = true;
+    this._feedbackData.errorMessage = '';
+    $.ajax({
+      url: VERIFY_EMAIL_URL,
+      type: 'POST',
+      data: {
+        email: this._submitData.email,
+        hubId: this._submitData.hubId,
+        verifyCaptcha: this._submitData.captcha,
+        verifyEmail: this._submitData.email,
+        verifyTarget: 'registerhubce'
+      }
+    }).done(_ => {
+      this.onRequestSucceeded();
+      if (this._submitData.acceptNewsletter) {
+        subscribeToNewsletter(this._submitData.email, 7); // FIXME move to backend
+      }
+    }).fail(xhr => {
+      this.onRequestFailed(xhr.responseJSON?.message || 'Sending confirmation email failed.');
+    });
+  }
+
+  getHubLicense() {
+    $.ajax({
+      url: GET_LICENSE_URL,
+      type: 'GET',
+      data: {
+        hubId: this._submitData.hubId
+      }
+    }).done(response => {
+      this._feedbackData.licenseText = response;
+    }).fail(xhr => {
+      this.onRequestFailed(xhr.responseJSON?.message || 'Fetching license failed.');
+    });
+  }
+
+  onRequestFailed(error) {
+    this._feedbackData.inProgress = false;
+    this._feedbackData.errorMessage = error;
+  }
+
+  onRequestSucceeded() {
+    this._feedbackData.currentStep++;
+    this._feedbackData.inProgress = false;
+    this._feedbackData.errorMessage = '';
+  }
+
+}

--- a/assets/js/hubce.js
+++ b/assets/js/hubce.js
@@ -85,7 +85,8 @@ class HubCE {
       url: REFRESH_LICENSE_URL,
       type: 'POST',
       data: {
-        token: this._submitData.oldLicense
+        token: this._submitData.oldLicense,
+        captcha: this._submitData.captcha
       }
     }).done(response => {
       this._feedbackData.licenseText = response;

--- a/assets/js/hubce.js
+++ b/assets/js/hubce.js
@@ -2,7 +2,7 @@
 
 // requires newsletter.js
 const VERIFY_EMAIL_URL = API_BASE_URL + '/connect/email/verify';
-const CLAIM_LICENSE_URL = API_BASE_URL + '/licenses/hub/prod';
+const REFRESH_LICENSE_URL = API_BASE_URL + '/licenses/hub/refresh';
 
 class HubCE {
 
@@ -11,7 +11,7 @@ class HubCE {
     this._feedbackData = feedbackData;
     this._submitData = submitData;
     this._searchParams = searchParams;
-    this._submitData.hubId = searchParams.get('hubId');
+    this._submitData.oldLicense = searchParams.get('oldLicense');
 
     // continue after email verified:
     if (searchParams.get('verifiedEmail')) {
@@ -65,7 +65,7 @@ class HubCE {
       type: 'POST',
       data: {
         email: this._submitData.email,
-        hubId: this._submitData.hubId,
+        oldLicense: this._submitData.oldLicense,
         verifyCaptcha: this._submitData.captcha,
         verifyEmail: this._submitData.email,
         verifyTarget: 'registerhubce'
@@ -82,11 +82,10 @@ class HubCE {
 
   getHubLicense() {
     $.ajax({
-      url: CLAIM_LICENSE_URL,
+      url: REFRESH_LICENSE_URL,
       type: 'POST',
       data: {
-        hubId: this._submitData.hubId,
-        captcha: this._submitData.captcha
+        token: this._submitData.oldLicense
       }
     }).done(response => {
       this._feedbackData.licenseText = response;

--- a/content/hub-register.de.html
+++ b/content/hub-register.de.html
@@ -1,0 +1,5 @@
+---
+title: "Cryptomator Hub: Registrieren"
+url: "/de/hub/register"
+type: "hub-register"
+---

--- a/content/hub-register.en.html
+++ b/content/hub-register.en.html
@@ -1,0 +1,5 @@
+---
+title: "Cryptomator Hub: Register"
+url: "/hub/register"
+type: "hub-register"
+---

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -667,6 +667,8 @@
   translation: "Step <span x-text=\"feedbackData.currentStep + 1\"></span> of <span x-text=\"steps.length\"></span>"
 - id: hub_ce_registration_steps_next
   translation: "Next"
+- id: hub_ce_registration_steps_continue
+  translation: "Continue"
 
 - id: hub_ce_registration_step_1_nav_title
   translation: "Email Address"
@@ -681,11 +683,19 @@
   translation: "Please confirm your email address"
 - id: hub_ce_registration_step_2_instructions
   translation: "We are going to send a confirmation email to <span x-text=\"submitData.email\"></span>"
+- id: hub_ce_registration_step_2_check_email
+  translation: "Please check your e-mails."
+- id: hub_ce_registration_step_2_email_verified
+  translation: "Your email has been verified successfully."
 
 - id: hub_ce_registration_step_3_license_nav_title
   translation: "License Key"
 - id: hub_ce_registration_step_3_license_title
   translation: "Your Community Edition License Key"
+- id: hub_ce_registration_step_3_loading
+  translation: "Loading license key..."
+- id: hub_ce_registration_step_3_success
+  translation: "Your new license key:"
 
 
 # Hub Managed

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -659,6 +659,35 @@
 - id: hub_demo_contact_us_button
   translation: "Contact Us"
 
+# Hub CE Registration
+- id: hub_ce_registration_description
+  translation: "Register your Cryptomator Hub instance for a free Community Edition license."
+
+- id: hub_ce_registration_steps_title
+  translation: "Step <span x-text=\"feedbackData.currentStep + 1\"></span> of <span x-text=\"steps.length\"></span>"
+- id: hub_ce_registration_steps_next
+  translation: "Next"
+
+- id: hub_ce_registration_step_1_nav_title
+  translation: "Email Address"
+- id: hub_ce_registration_step_1_title
+  translation: "What's your email address?"
+- id: hub_ce_registration_step_1_email_placeholder
+  translation: "Email address"
+
+- id: hub_ce_registration_step_2_confirmation_nav_title
+  translation: "Confirmation"
+- id: hub_ce_registration_step_2_confirmation_title
+  translation: "Please confirm your email address"
+- id: hub_ce_registration_step_2_instructions
+  translation: "We are going to send a confirmation email to <span x-text=\"submitData.email\"></span>"
+
+- id: hub_ce_registration_step_3_license_nav_title
+  translation: "License Key"
+- id: hub_ce_registration_step_3_license_title
+  translation: "Your Community Edition License Key"
+
+
 # Hub Managed
 - id: hub_managed_description
   translation: "Request access to a managed instance of Cryptomator Hub and get your team on board with client-side encryption for your cloud storage."

--- a/layouts/hub-register/single.html
+++ b/layouts/hub-register/single.html
@@ -2,7 +2,7 @@
   {{ partial "altcha-css.html" . }}
 {{ end }}
 {{ define "main" }}
-  <section x-data="{steps: ['{{ i18n "hub_ce_registration_step_1_nav_title" }}', '{{ i18n "hub_ce_registration_step_2_confirmation_nav_title" }}', '{{ i18n "hub_ce_registration_step_3_license_nav_title" }}'], feedbackData: {currentStep: 0, success: false, inProgress: false, errorMessage: '', licenseText: null, emailSent: false, emailVerified: false}, submitData: {captcha: null, oldLicense: '', email: '', acceptNewsletter: false}, acceptTerms: false, hubCE: null, captchaState: null}" x-init="hubCE = new HubCE($refs.form, feedbackData, submitData, new URLSearchParams(location.hash.substring(1)))" class="container py-12">
+  <section x-data="{steps: ['{{ i18n "hub_ce_registration_step_1_nav_title" }}', '{{ i18n "hub_ce_registration_step_2_confirmation_nav_title" }}', '{{ i18n "hub_ce_registration_step_3_license_nav_title" }}'], feedbackData: {currentStep: 0, success: false, inProgress: false, errorMessage: '', licenseText: null, emailSent: false, emailVerified: false}, submitData: {captcha: null, oldLicense: '', email: '', acceptNewsletter: false}, acceptTerms: false, hubCE: null, captchaState: null, returnUrl: null}" x-init="const params = new URLSearchParams(location.hash.substring(1)); returnUrl = params.get('returnUrl'); hubCE = new HubCE($refs.form, feedbackData, submitData, params)" class="container py-12">
     <header class="mb-6">
       <h1 class="font-h1 mb-8">{{ .Title }}</h1>
       <p class="lead">{{ i18n "hub_ce_registration_description" }}</p>
@@ -202,7 +202,7 @@
                 <p class="font-p mb-4">{{ i18n "hub_ce_registration_step_3_success" }}</p>
                 <textarea class="block input-box w-full h-32 md:h-48 mb-8" x-text="feedbackData.licenseText" readonly></textarea>
                 <div class="mt-auto">
-                  <button class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-step-1">
+                  <button @click="window.location.href = returnUrl + '/app/admin/settings?token=' + encodeURIComponent(feedbackData.licenseText)" class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-return-to-hub">
                     <i :class="{'fa-chevron-right': !feedbackData.inProgress, 'fa-spinner fa-spin': feedbackData.inProgress}" class="fa-solid" aria-hidden="true"></i>
                     Todo: Return to Hub
                   </button>

--- a/layouts/hub-register/single.html
+++ b/layouts/hub-register/single.html
@@ -202,7 +202,7 @@
                 <p class="font-p mb-4">{{ i18n "hub_ce_registration_step_3_success" }}</p>
                 <textarea class="block input-box w-full h-32 md:h-48 mb-8" x-text="feedbackData.licenseText" readonly></textarea>
                 <div class="mt-auto">
-                  <button @click="window.location.href = returnUrl + '/app/admin/settings?token=' + encodeURIComponent(feedbackData.licenseText)" class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-return-to-hub">
+                  <button @click="window.location.href = returnUrl + '?token=' + encodeURIComponent(feedbackData.licenseText)" class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-return-to-hub">
                     <i :class="{'fa-chevron-right': !feedbackData.inProgress, 'fa-spinner fa-spin': feedbackData.inProgress}" class="fa-solid" aria-hidden="true"></i>
                     Todo: Return to Hub
                   </button>

--- a/layouts/hub-register/single.html
+++ b/layouts/hub-register/single.html
@@ -8,59 +8,70 @@
       <p class="lead">{{ i18n "hub_ce_registration_description" }}</p>
     </header>
 
-    <form x-ref="form" @submit.prevent="hubCE.sendConfirmationEmail(); $refs.captcha.reset()">
-      <section class="white-box md:min-h-110 px-4 py-5 md:p-6 md:grid md:grid-cols-3 md:gap-6">
-        <header class="mb-8 md:col-span-1 md:mt-4">
-          <nav class="flex items-center justify-center gap-6" aria-label="Progress">
-            <p class="font-p text-sm text-gray-500 md:hidden">
-              {{ i18n "hub_ce_registration_steps_title" | safeHTML }}
-            </p>
-            <ol role="list" class="flex items-center gap-3 md:flex-col md:items-start md:gap-6">
-              <template x-for="(step, index) in steps" :key="index">
-                <li>
-                  <!-- Complete Step -->
-                  <template x-if="index < feedbackData.currentStep">
-                    <a href="#" class="group" @click.prevent="feedbackData.currentStep = index" :data-umami-event="`hub-managed-nav-step-${index + 1}`">
-                      <span class="flex items-center gap-3">
-                        <div class="relative flex w-5 h-5 shrink-0 items-center justify-center">
-                          <svg class="w-full h-full text-primary group-hover:text-secondary" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                            <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
-                          </svg>
-                        </div>
-                        <p class="hidden md:block font-p text-sm text-gray-500 group-hover:text-gray-900" x-text="step"></p>
-                      </span>
-                    </a>
-                  </template>
 
-                  <!-- Current Step -->
-                  <template x-if="index === feedbackData.currentStep">
-                    <div class="flex items-center gap-3" aria-current="step">
-                      <div class="relative flex w-5 h-5 shrink-0 items-center justify-center" aria-hidden="true">
-                        <span class="absolute w-4 h-4 rounded-full bg-primary-l2"></span>
-                        <span class="relative block w-2 h-2 rounded-full bg-primary"></span>
+    <section class="white-box md:min-h-110 px-4 py-5 md:p-6 md:grid md:grid-cols-3 md:gap-6">
+      <header class="mb-8 md:col-span-1 md:mt-4">
+        <nav class="flex items-center justify-center gap-6" aria-label="Progress">
+          <p class="font-p text-sm text-gray-500 md:hidden">
+            {{ i18n "hub_ce_registration_steps_title" | safeHTML }}
+          </p>
+          <ol role="list" class="flex items-center gap-3 md:flex-col md:items-start md:gap-6">
+            <template x-for="(step, index) in steps" :key="index">
+              <li>
+                <!-- Complete Step -->
+                <template x-if="index < feedbackData.currentStep &amp;&amp; !feedbackData.success">
+                  <a href="#" class="group" @click.prevent="feedbackData.currentStep = index" :data-umami-event="`hub-managed-nav-step-${index + 1}`">
+                    <span class="flex items-center gap-3">
+                      <div class="relative flex w-5 h-5 shrink-0 items-center justify-center">
+                        <svg class="w-full h-full text-primary group-hover:text-secondary" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                          <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
+                        </svg>
                       </div>
-                      <p class="hidden md:block font-p text-sm font-medium text-primary" x-text="step"></p>
+                      <p class="hidden md:block font-p text-sm text-gray-500 group-hover:text-gray-900" x-text="step"></p>
+                    </span>
+                  </a>
+                </template>
+                <template x-if="index < feedbackData.currentStep &amp;&amp; feedbackData.success">
+                  <span class="flex items-center gap-3">
+                    <div class="relative flex w-5 h-5 shrink-0 items-center justify-center">
+                      <svg class="w-full h-full text-primary group-hover:text-secondary" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
+                      </svg>
                     </div>
-                  </template>
+                    <p class="hidden md:block font-p text-sm text-gray-500 group-hover:text-gray-900" x-text="step"></p>
+                  </span>
+                </template>
 
-                  <!-- Upcoming Step -->
-                  <template x-if="index > feedbackData.currentStep">
-                    <div class="flex items-center gap-3">
-                      <div class="relative flex w-5 h-5 shrink-0 items-center justify-center" aria-hidden="true">
-                        <div class="w-2 h-2 rounded-full bg-gray-300"></div>
-                      </div>
-                      <p class="hidden md:block font-p text-sm text-gray-500" x-text="step"></p>
+                <!-- Current Step -->
+                <template x-if="index === feedbackData.currentStep">
+                  <div class="flex items-center gap-3" aria-current="step">
+                    <div class="relative flex w-5 h-5 shrink-0 items-center justify-center" aria-hidden="true">
+                      <span class="absolute w-4 h-4 rounded-full bg-primary-l2"></span>
+                      <span class="relative block w-2 h-2 rounded-full bg-primary"></span>
                     </div>
-                  </template>
-                </li>
-              </template>
-            </ol>
-          </nav>
-        </header>
+                    <p class="hidden md:block font-p text-sm font-medium text-primary" x-text="step"></p>
+                  </div>
+                </template>
 
+                <!-- Upcoming Step -->
+                <template x-if="index > feedbackData.currentStep">
+                  <div class="flex items-center gap-3">
+                    <div class="relative flex w-5 h-5 shrink-0 items-center justify-center" aria-hidden="true">
+                      <div class="w-2 h-2 rounded-full bg-gray-300"></div>
+                    </div>
+                    <p class="hidden md:block font-p text-sm text-gray-500" x-text="step"></p>
+                  </div>
+                </template>
+              </li>
+            </template>
+          </ol>
+        </nav>
+      </header>
+
+      <form x-ref="form" class="md:col-span-2" @submit.prevent="hubCE.submit(); $refs.captcha.reset()">
         <!-- Step 1: Email Address -->
         <template x-if="feedbackData.currentStep == 0">
-          <div class="md:col-span-2 grid grid-cols-6 gap-6">
+          <div class="grid grid-cols-6 gap-6">
             <div class="flex flex-col col-span-6 lg:col-span-4">
               <p class="hidden md:block font-p text-sm text-gray-500 mb-2">
                 {{ i18n "hub_managed_steps_title" | safeHTML }}
@@ -110,7 +121,7 @@
           </div>
         </template>
 
-        <!-- Step 3: License Key (loading...) -->
+        <!-- Step 3a: License Key (loading...) -->
         <template x-if="feedbackData.currentStep == 2 &amp;&amp; !feedbackData.success">
           <div class="md:col-span-2 grid grid-cols-6 gap-6">
             <div class="flex flex-col col-span-6 lg:col-span-4">
@@ -125,7 +136,7 @@
           </div>
         </template>
 
-        <!-- Step 3: License Key (success) -->
+        <!-- Step 3b: License Key (success) -->
         <template x-if="feedbackData.currentStep == 2 &amp;&amp; feedbackData.success">
           <div class="md:col-span-2 grid grid-cols-6 gap-6">
             <div class="flex flex-col col-span-6 lg:col-span-4">
@@ -136,6 +147,8 @@
                 {{ i18n "hub_ce_registration_step_3_license_title" }}
               </h2>
               <p>Todo: return URL</p>
+              {{ $challengeUrl := printf "%s/licenses/hub/challenge" .Site.Params.apiBaseUrl }}
+              {{ partial "captcha.html" (dict "challengeUrl" $challengeUrl "captchaPayload" "submitData.captcha" "captchaState" "captchaState") }}
               <textarea class="block input-box w-full h-48 mb-8" x-text="feedbackData.licenseText" readonly></textarea>
              
               <div class="mt-auto">
@@ -148,8 +161,8 @@
             </div>
           </div>
         </template>
-      </section>
-    </form>
+      </form>
+    </section>
   </section>
 {{ end }}
 {{ define "script" }}

--- a/layouts/hub-register/single.html
+++ b/layouts/hub-register/single.html
@@ -2,7 +2,7 @@
   {{ partial "altcha-css.html" . }}
 {{ end }}
 {{ define "main" }}
-  <section x-data="{steps: ['{{ i18n "hub_ce_registration_step_1_nav_title" }}', '{{ i18n "hub_ce_registration_step_2_confirmation_nav_title" }}', '{{ i18n "hub_ce_registration_step_3_license_nav_title" }}'], feedbackData: {currentStep: 0, success: false, inProgress: false, errorMessage: '', licenseText: null}, submitData: {captcha: null, oldLicense: '', email: '', acceptNewsletter: false}, acceptTerms: false, hubCE: null, captchaState: null}" x-init="hubCE = new HubCE($refs.form, feedbackData, submitData, new URLSearchParams(location.hash.substring(1)))" class="container py-12">
+  <section x-data="{steps: ['{{ i18n "hub_ce_registration_step_1_nav_title" }}', '{{ i18n "hub_ce_registration_step_2_confirmation_nav_title" }}', '{{ i18n "hub_ce_registration_step_3_license_nav_title" }}'], feedbackData: {currentStep: 0, success: false, inProgress: false, errorMessage: '', licenseText: null, emailSent: false, emailVerified: false}, submitData: {captcha: null, oldLicense: '', email: '', acceptNewsletter: false}, acceptTerms: false, hubCE: null, captchaState: null}" x-init="hubCE = new HubCE($refs.form, feedbackData, submitData, new URLSearchParams(location.hash.substring(1)))" class="container py-12">
     <header class="mb-6">
       <h1 class="font-h1 mb-8">{{ .Title }}</h1>
       <p class="lead">{{ i18n "hub_ce_registration_description" }}</p>
@@ -18,8 +18,8 @@
           <ol role="list" class="flex items-center gap-3 md:flex-col md:items-start md:gap-6">
             <template x-for="(step, index) in steps" :key="index">
               <li>
-                <!-- Complete Step -->
-                <template x-if="index < feedbackData.currentStep &amp;&amp; !feedbackData.success">
+                <!-- Complete Step (clickable) -->
+                <template x-if="index < feedbackData.currentStep &amp;&amp; !feedbackData.success &amp;&amp; !feedbackData.emailSent">
                   <a href="#" class="group" @click.prevent="feedbackData.currentStep = index" :data-umami-event="`hub-managed-nav-step-${index + 1}`">
                     <span class="flex items-center gap-3">
                       <div class="relative flex w-5 h-5 shrink-0 items-center justify-center">
@@ -31,7 +31,8 @@
                     </span>
                   </a>
                 </template>
-                <template x-if="index < feedbackData.currentStep &amp;&amp; feedbackData.success">
+                <!-- Complete Step (not clickable) -->
+                <template x-if="index < feedbackData.currentStep &amp;&amp; (feedbackData.success || feedbackData.emailSent)">
                   <span class="flex items-center gap-3">
                     <div class="relative flex w-5 h-5 shrink-0 items-center justify-center">
                       <svg class="w-full h-full text-primary group-hover:text-secondary" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -91,10 +92,10 @@
           </div>
         </template>
 
-          <!-- Step 2: Confirmation -->
-        <template x-if="feedbackData.currentStep == 1">
-          <div class="md:col-span-2 grid grid-cols-6 gap-6">
-            <div class="flex flex-col col-span-6 lg:col-span-4">
+          <!-- Step 2a: Confirmation (form with checkboxes) -->
+        <template x-if="feedbackData.currentStep == 1 &amp;&amp; !feedbackData.emailSent &amp;&amp; !feedbackData.emailVerified">
+          <div class="md:col-span-2 gap-6">
+            <div class="flex flex-col">
               <p class="hidden md:block font-p text-sm text-gray-500 mb-2">
                 {{ i18n "hub_managed_steps_title" | safeHTML }}
               </p>
@@ -121,23 +122,44 @@
           </div>
         </template>
 
-        <!-- Step 3a: License Key (loading...) -->
-        <template x-if="feedbackData.currentStep == 2 &amp;&amp; !feedbackData.success">
-          <div class="md:col-span-2 grid grid-cols-6 gap-6">
-            <div class="flex flex-col col-span-6 lg:col-span-4">
+        <!-- Step 2b: Confirmation (email sent, waiting for verification) -->
+        <template x-if="feedbackData.currentStep == 1 &amp;&amp; feedbackData.emailSent &amp;&amp; !feedbackData.emailVerified">
+          <div class="md:col-span-2 gap-6">
+            <div class="flex flex-col">
               <p class="hidden md:block font-p text-sm text-gray-500 mb-2">
                 {{ i18n "hub_managed_steps_title" | safeHTML }}
               </p>
               <h2 class="font-h2 mb-6">
-                {{ i18n "hub_ce_registration_step_3_license_title" }}
+                {{ i18n "hub_ce_registration_step_2_confirmation_title" }}
               </h2>
-              <p>Todo: Please check your e-mails.</p>
+              <p class="font-p mb-6">{{ i18n "hub_ce_registration_step_2_check_email" | safeHTML }}</p>
             </div>
           </div>
         </template>
 
-        <!-- Step 3b: License Key (success) -->
-        <template x-if="feedbackData.currentStep == 2 &amp;&amp; feedbackData.success">
+        <!-- Step 2c: Confirmation (email verified, show continue button) -->
+        <template x-if="feedbackData.currentStep == 1 &amp;&amp; feedbackData.emailVerified">
+          <div class="md:col-span-2 gap-6">
+            <div class="flex flex-col">
+              <p class="hidden md:block font-p text-sm text-gray-500 mb-2">
+                {{ i18n "hub_managed_steps_title" | safeHTML }}
+              </p>
+              <h2 class="font-h2 mb-6">
+                {{ i18n "hub_ce_registration_step_2_confirmation_title" }}
+              </h2>
+              <p class="font-p mb-6">{{ i18n "hub_ce_registration_step_2_email_verified" | safeHTML }}</p>
+              <div class="mt-auto">
+                <button @click.prevent="feedbackData.currentStep++; feedbackData.success = true" class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-continue">
+                  <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
+                  {{ i18n "hub_ce_registration_steps_continue" }}
+                </button>
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <!-- Step 3: License Key -->
+        <template x-if="feedbackData.currentStep == 2">
           <div class="md:col-span-2 grid grid-cols-6 gap-6">
             <div class="flex flex-col col-span-6 lg:col-span-4">
               <p class="hidden md:block font-p text-sm text-gray-500 mb-2">
@@ -146,17 +168,45 @@
               <h2 class="font-h2 mb-6">
                 {{ i18n "hub_ce_registration_step_3_license_title" }}
               </h2>
-              <p>Todo: return URL</p>
-              {{ $challengeUrl := printf "%s/licenses/hub/challenge" .Site.Params.apiBaseUrl }}
-              {{ partial "captcha.html" (dict "challengeUrl" $challengeUrl "captchaPayload" "submitData.captcha" "captchaState" "captchaState") }}
-              <textarea class="block input-box w-full h-48 mb-8" x-text="feedbackData.licenseText" readonly></textarea>
-             
-              <div class="mt-auto">
-                <p :class="{'hidden': !feedbackData.errorMessage}" class="text-sm text-red-600 mb-2" x-text="feedbackData.errorMessage"></p>
-                <button class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-step-1">
-                  <i :class="{'fa-chevron-right': !feedbackData.inProgress, 'fa-spinner fa-spin': feedbackData.inProgress}" class="fa-solid" aria-hidden="true"></i>
-                  Todo: Return to Hub
-                </button>
+
+              <!-- Captcha (auto-starts on load, hidden when done) -->
+              <div x-show="!feedbackData.licenseText" class="mb-4">
+                <altcha-widget
+                  challengeurl="{{ .Site.Params.apiBaseUrl }}/licenses/hub/challenge"
+                  hidelogo
+                  hidefooter
+                  auto="onload"
+                  @statechange="captchaState = $event.detail.state; if ($event.detail.state === 'verified') { submitData.captcha = $event.detail.payload; hubCE.getHubLicense() }"
+                  :strings="JSON.stringify({
+                    label: '{{ i18n "altcha_label" }}',
+                    error: '{{ i18n "altcha_error" }}',
+                    expired: '{{ i18n "altcha_expired" }}',
+                    verified: '{{ i18n "altcha_verified" }}',
+                    verifying: '{{ i18n "altcha_verifying" }}',
+                    waitAlert: '{{ i18n "altcha_waitAlert" }}'
+                  })"
+                  x-ref="licenseCaptcha"
+                ></altcha-widget>
+              </div>
+
+              <!-- Loading state -->
+              <div x-show="captchaState === 'verified' &amp;&amp; !feedbackData.licenseText &amp;&amp; !feedbackData.errorMessage" class="mb-8">
+                <p class="font-p text-gray-500">
+                  <i class="fa-solid fa-spinner fa-spin mr-2" aria-hidden="true"></i>
+                  {{ i18n "hub_ce_registration_step_3_loading" }}
+                </p>
+              </div>
+
+              <!-- License Key display -->
+              <div x-show="feedbackData.licenseText">
+                <p class="font-p mb-4">{{ i18n "hub_ce_registration_step_3_success" }}</p>
+                <textarea class="block input-box w-full h-32 md:h-48 mb-8" x-text="feedbackData.licenseText" readonly></textarea>
+                <div class="mt-auto">
+                  <button class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-step-1">
+                    <i :class="{'fa-chevron-right': !feedbackData.inProgress, 'fa-spinner fa-spin': feedbackData.inProgress}" class="fa-solid" aria-hidden="true"></i>
+                    Todo: Return to Hub
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/layouts/hub-register/single.html
+++ b/layouts/hub-register/single.html
@@ -2,7 +2,7 @@
   {{ partial "altcha-css.html" . }}
 {{ end }}
 {{ define "main" }}
-  <section x-data="{steps: ['{{ i18n "hub_ce_registration_step_1_nav_title" }}', '{{ i18n "hub_ce_registration_step_2_confirmation_nav_title" }}', '{{ i18n "hub_ce_registration_step_3_license_nav_title" }}'], feedbackData: {currentStep: 0, success: false, inProgress: false, errorMessage: '', licenseText: null}, submitData: {captcha: null, hubId: '', email: '', acceptNewsletter: false}, acceptTerms: false, hubCE: null, captchaState: null}" x-init="hubCE = new HubCE($refs.form, feedbackData, submitData, new URLSearchParams(location.search))" class="container py-12">
+  <section x-data="{steps: ['{{ i18n "hub_ce_registration_step_1_nav_title" }}', '{{ i18n "hub_ce_registration_step_2_confirmation_nav_title" }}', '{{ i18n "hub_ce_registration_step_3_license_nav_title" }}'], feedbackData: {currentStep: 0, success: false, inProgress: false, errorMessage: '', licenseText: null}, submitData: {captcha: null, oldLicense: '', email: '', acceptNewsletter: false}, acceptTerms: false, hubCE: null, captchaState: null}" x-init="hubCE = new HubCE($refs.form, feedbackData, submitData, new URLSearchParams(location.hash.substring(1)))" class="container py-12">
     <header class="mb-6">
       <h1 class="font-h1 mb-8">{{ .Title }}</h1>
       <p class="lead">{{ i18n "hub_ce_registration_description" }}</p>
@@ -82,7 +82,7 @@
               <input type="email" id="email" class="block input-box w-full mb-8" placeholder="{{ i18n "hub_ce_registration_step_1_email_placeholder" }}" x-init="$el.focus()" x-model="submitData.email" @blur="$el.classList.add('show-invalid')" required>
               <div class="mt-auto">
                 <p :class="{'hidden': !feedbackData.errorMessage}" class="text-sm text-red-600 mb-2" x-text="feedbackData.errorMessage"></p>
-                <button :disabled="feedbackData.inProgress || !submitData.hubId" @click.prevent="hubCE.validateEmail()" class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-step-1">
+                <button :disabled="feedbackData.inProgress || !submitData.oldLicense" @click.prevent="hubCE.validateEmail()" class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-step-1">
                   <i :class="{'fa-chevron-right': !feedbackData.inProgress, 'fa-spinner fa-spin': feedbackData.inProgress}" class="fa-solid" aria-hidden="true"></i>
                   {{ i18n "hub_ce_registration_steps_next" }}
                 </button>

--- a/layouts/hub-register/single.html
+++ b/layouts/hub-register/single.html
@@ -202,10 +202,10 @@
                 <p class="font-p mb-4">{{ i18n "hub_ce_registration_step_3_success" }}</p>
                 <textarea class="block input-box w-full h-32 md:h-48 mb-8" x-text="feedbackData.licenseText" readonly></textarea>
                 <div class="mt-auto">
-                  <button @click="window.location.href = returnUrl + '?token=' + encodeURIComponent(feedbackData.licenseText)" class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-return-to-hub">
-                    <i :class="{'fa-chevron-right': !feedbackData.inProgress, 'fa-spinner fa-spin': feedbackData.inProgress}" class="fa-solid" aria-hidden="true"></i>
+                  <a :href="returnUrl + '?token=' + encodeURIComponent(feedbackData.licenseText)" class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-return-to-hub">
+                    <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
                     Todo: Return to Hub
-                  </button>
+                  </a>
                 </div>
               </div>
             </div>

--- a/layouts/hub-register/single.html
+++ b/layouts/hub-register/single.html
@@ -1,0 +1,175 @@
+{{ define "preloads" }}
+  {{ partial "altcha-css.html" . }}
+{{ end }}
+{{ define "main" }}
+  <section x-data="{steps: ['{{ i18n "hub_ce_registration_step_1_nav_title" }}', '{{ i18n "hub_ce_registration_step_2_confirmation_nav_title" }}', '{{ i18n "hub_ce_registration_step_3_license_nav_title" }}'], feedbackData: {currentStep: 0, success: false, inProgress: false, errorMessage: '', licenseText: null}, submitData: {captcha: null, hubId: '', email: '', acceptNewsletter: false}, acceptTerms: false, hubCE: null, captchaState: null}" x-init="hubCE = new HubCE($refs.form, feedbackData, submitData, new URLSearchParams(location.search))" class="container py-12">
+    <header class="mb-6">
+      <h1 class="font-h1 mb-8">{{ .Title }}</h1>
+      <p class="lead">{{ i18n "hub_ce_registration_description" }}</p>
+    </header>
+
+    <form x-ref="form" @submit.prevent="hubCE.sendConfirmationEmail(); $refs.captcha.reset()">
+      <section class="white-box md:min-h-110 px-4 py-5 md:p-6 md:grid md:grid-cols-3 md:gap-6">
+        <header class="mb-8 md:col-span-1 md:mt-4">
+          <nav class="flex items-center justify-center gap-6" aria-label="Progress">
+            <p class="font-p text-sm text-gray-500 md:hidden">
+              {{ i18n "hub_ce_registration_steps_title" | safeHTML }}
+            </p>
+            <ol role="list" class="flex items-center gap-3 md:flex-col md:items-start md:gap-6">
+              <template x-for="(step, index) in steps" :key="index">
+                <li>
+                  <!-- Complete Step -->
+                  <template x-if="index < feedbackData.currentStep">
+                    <a href="#" class="group" @click.prevent="feedbackData.currentStep = index" :data-umami-event="`hub-managed-nav-step-${index + 1}`">
+                      <span class="flex items-center gap-3">
+                        <div class="relative flex w-5 h-5 shrink-0 items-center justify-center">
+                          <svg class="w-full h-full text-primary group-hover:text-secondary" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                            <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
+                          </svg>
+                        </div>
+                        <p class="hidden md:block font-p text-sm text-gray-500 group-hover:text-gray-900" x-text="step"></p>
+                      </span>
+                    </a>
+                  </template>
+
+                  <!-- Current Step -->
+                  <template x-if="index === feedbackData.currentStep">
+                    <div class="flex items-center gap-3" aria-current="step">
+                      <div class="relative flex w-5 h-5 shrink-0 items-center justify-center" aria-hidden="true">
+                        <span class="absolute w-4 h-4 rounded-full bg-primary-l2"></span>
+                        <span class="relative block w-2 h-2 rounded-full bg-primary"></span>
+                      </div>
+                      <p class="hidden md:block font-p text-sm font-medium text-primary" x-text="step"></p>
+                    </div>
+                  </template>
+
+                  <!-- Upcoming Step -->
+                  <template x-if="index > feedbackData.currentStep">
+                    <div class="flex items-center gap-3">
+                      <div class="relative flex w-5 h-5 shrink-0 items-center justify-center" aria-hidden="true">
+                        <div class="w-2 h-2 rounded-full bg-gray-300"></div>
+                      </div>
+                      <p class="hidden md:block font-p text-sm text-gray-500" x-text="step"></p>
+                    </div>
+                  </template>
+                </li>
+              </template>
+            </ol>
+          </nav>
+        </header>
+
+        <!-- Step 1: Email Address -->
+        <template x-if="feedbackData.currentStep == 0">
+          <div class="md:col-span-2 grid grid-cols-6 gap-6">
+            <div class="flex flex-col col-span-6 lg:col-span-4">
+              <p class="hidden md:block font-p text-sm text-gray-500 mb-2">
+                {{ i18n "hub_managed_steps_title" | safeHTML }}
+              </p>
+              <h2 class="font-h2 mb-6">
+                {{ i18n "hub_ce_registration_step_1_title" }}
+              </h2>
+              <input type="email" id="email" class="block input-box w-full mb-8" placeholder="{{ i18n "hub_ce_registration_step_1_email_placeholder" }}" x-init="$el.focus()" x-model="submitData.email" @blur="$el.classList.add('show-invalid')" required>
+              <div class="mt-auto">
+                <p :class="{'hidden': !feedbackData.errorMessage}" class="text-sm text-red-600 mb-2" x-text="feedbackData.errorMessage"></p>
+                <button :disabled="feedbackData.inProgress || !submitData.hubId" @click.prevent="hubCE.validateEmail()" class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-step-1">
+                  <i :class="{'fa-chevron-right': !feedbackData.inProgress, 'fa-spinner fa-spin': feedbackData.inProgress}" class="fa-solid" aria-hidden="true"></i>
+                  {{ i18n "hub_ce_registration_steps_next" }}
+                </button>
+              </div>
+            </div>
+          </div>
+        </template>
+
+          <!-- Step 2: Confirmation -->
+        <template x-if="feedbackData.currentStep == 1">
+          <div class="md:col-span-2 grid grid-cols-6 gap-6">
+            <div class="flex flex-col col-span-6 lg:col-span-4">
+              <p class="hidden md:block font-p text-sm text-gray-500 mb-2">
+                {{ i18n "hub_managed_steps_title" | safeHTML }}
+              </p>
+              <h2 class="font-h2 mb-6">
+                {{ i18n "hub_ce_registration_step_2_confirmation_title" }}
+              </h2>
+              <p class="font-p mb-6">{{ i18n "hub_ce_registration_step_2_instructions" | safeHTML }}</p>
+              <p class="font-p text-sm mb-2">
+                {{ partial "checkbox.html" (dict "context" . "alpineVariable" "acceptTerms" "label" (i18n "accept_hub_managed_terms_and_privacy" | safeHTML)) }}
+              </p>
+              <p class="font-p text-sm mb-2">
+                {{ partial "checkbox.html" (dict "context" . "alpineVariable" "submitData.acceptNewsletter" "label" (i18n "accept_hub_newsletter_optional")) }}
+              </p>
+              <div class="mt-auto">
+                <p :class="{'hidden': !feedbackData.errorMessage}" class="text-sm text-red-600 mb-2" x-text="feedbackData.errorMessage"></p>
+                <button :disabled="feedbackData.inProgress || !acceptTerms || captchaState == 'verifying'" type="submit" class="btn btn-primary w-full md:w-64" data-umami-event="hub-managed-form" x-cloak>
+                  <i :class="{'fa-paper-plane': !feedbackData.inProgress, 'fa-spinner fa-spin': feedbackData.inProgress}" class="fa-solid" aria-hidden="true"></i>
+                  {{ i18n "hub_managed_step_4_submit" }}
+                </button>
+                {{ $challengeUrl := printf "%s/connect/email/challenge" .Site.Params.apiBaseUrl }}
+                {{ partial "captcha.html" (dict "challengeUrl" $challengeUrl "captchaPayload" "submitData.captcha" "captchaState" "captchaState") }}
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <!-- Step 3: License Key (loading...) -->
+        <template x-if="feedbackData.currentStep == 2 &amp;&amp; !feedbackData.success">
+          <div class="md:col-span-2 grid grid-cols-6 gap-6">
+            <div class="flex flex-col col-span-6 lg:col-span-4">
+              <p class="hidden md:block font-p text-sm text-gray-500 mb-2">
+                {{ i18n "hub_managed_steps_title" | safeHTML }}
+              </p>
+              <h2 class="font-h2 mb-6">
+                {{ i18n "hub_ce_registration_step_3_license_title" }}
+              </h2>
+              <p>Todo: Please check your e-mails.</p>
+            </div>
+          </div>
+        </template>
+
+        <!-- Step 3: License Key (success) -->
+        <template x-if="feedbackData.currentStep == 2 &amp;&amp; feedbackData.success">
+          <div class="md:col-span-2 grid grid-cols-6 gap-6">
+            <div class="flex flex-col col-span-6 lg:col-span-4">
+              <p class="hidden md:block font-p text-sm text-gray-500 mb-2">
+                {{ i18n "hub_managed_steps_title" | safeHTML }}
+              </p>
+              <h2 class="font-h2 mb-6">
+                {{ i18n "hub_ce_registration_step_3_license_title" }}
+              </h2>
+              <p>Todo: return URL</p>
+              <textarea class="block input-box w-full h-48 mb-8" x-text="feedbackData.licenseText" readonly></textarea>
+             
+              <div class="mt-auto">
+                <p :class="{'hidden': !feedbackData.errorMessage}" class="text-sm text-red-600 mb-2" x-text="feedbackData.errorMessage"></p>
+                <button class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-step-1">
+                  <i :class="{'fa-chevron-right': !feedbackData.inProgress, 'fa-spinner fa-spin': feedbackData.inProgress}" class="fa-solid" aria-hidden="true"></i>
+                  Todo: Return to Hub
+                </button>
+              </div>
+            </div>
+          </div>
+        </template>
+      </section>
+    </form>
+  </section>
+{{ end }}
+{{ define "script" }}
+  {{ if hugo.IsDevelopment }}
+    {{ $newsletterJs := resources.Get "js/newsletter.js" }}
+    <script type="text/javascript" src="{{ $newsletterJs.RelPermalink }}" defer></script>
+    {{ $hubCeJs := resources.Get "js/hubce.js" }}
+    <script type="text/javascript" src="{{ $hubCeJs.RelPermalink }}" defer></script>
+    {{ $altchaJs := resources.Get "js/altcha/altcha.js" }}
+    <script type="module" src="{{ $altchaJs.RelPermalink }}" defer></script>
+    {{ $altchaWorkerJs := resources.Get "js/altcha/worker.js" }}
+    <script type="module" src="{{ $altchaWorkerJs.RelPermalink }}" defer></script>
+  {{ else }}
+    {{ $newsletterJs := resources.Get "js/newsletter.js" | minify | fingerprint }}
+    <script type="text/javascript" src="{{ $newsletterJs.RelPermalink }}" integrity="{{ $newsletterJs.Data.Integrity }}" defer></script>
+    {{ $hubCeJs := resources.Get "js/hubce.js" | minify | fingerprint }}
+    <script type="text/javascript" src="{{ $hubCeJs.RelPermalink }}" integrity="{{ $hubCeJs.Data.Integrity }}" defer></script>
+    {{ $altchaJs := resources.Get "js/altcha/altcha.js" | minify | fingerprint }}
+    <script type="module" src="{{ $altchaJs.RelPermalink }}" integrity="{{ $altchaJs.Data.Integrity }}" defer></script>
+    {{ $altchaWorkerJs := resources.Get "js/altcha/worker.js" }}
+    <script type="module" src="{{ $altchaWorkerJs.RelPermalink }}" integrity="{{ $altchaWorkerJs.Data.Integrity }}" defer></script>
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
This is the website counterpart of https://github.com/cryptomator/api/pull/12.

It adds the new page `/hub/register`, which has a four step process:
1. enter email address
2. review and accept license terms
3. verify email address (which will create a CE billing record in the backend)
4. invoke `POST /licenses/hub/refresh` endpoint to trade in trial license for new CE license

> [!note]
> In order to start this workflow, the old trial license must be passed to the site via the url fragment, e.g. `/hub/register#oldLicense=ey...`

This is just the bare minimum, I imagine to improve this workflow by integrating it with Hub via automatic redirect.