### PR TITLE
Return Hub license via URL fragment to keep long tokens out of URLs

### DIFF
--- a/assets/js/hubce.js
+++ b/assets/js/hubce.js
@@ -13,6 +13,7 @@ class HubCE {
     this._searchParams = searchParams;
     this._submitData.oldLicense = searchParams.get('oldLicense');
     this._submitData.returnUrl = searchParams.get('returnUrl');
+    this._submitData.returnUrlFromFragment = searchParams.get('returnUrlFromFragment') === 'true';
 
     // continue after email verified:
     if (searchParams.get('verifiedEmail')) {
@@ -109,6 +110,16 @@ class HubCE {
     this._feedbackData.emailSent = true;
     this._feedbackData.inProgress = false;
     this._feedbackData.errorMessage = '';
+  }
+
+  returnToHubUrl() {
+    let url = new URL(this._submitData.returnUrl);
+    if (this._submitData.returnUrlFromFragment) {
+      url.hash = 'token=' + encodeURIComponent(this._feedbackData.licenseText);
+    } else {
+      url.searchParams.set('token', this._feedbackData.licenseText);
+    }
+    return url.href;
   }
 
 }

--- a/assets/js/hubsubscription.js
+++ b/assets/js/hubsubscription.js
@@ -6,14 +6,15 @@ const GENERATE_PAY_LINK_URL = LEGACY_STORE_URL + '/hub/generate-pay-link';
 const MANAGE_SUBSCRIPTION_URL = LEGACY_STORE_URL + '/hub/manage-subscription';
 const UPDATE_PAYMENT_METHOD_URL = LEGACY_STORE_URL + '/hub/update-payment-method';
 const REFRESH_LICENSE_URL = API_BASE_URL + '/licenses/hub/refresh';
+const FRAGMENT_PARAMS_STORAGE_KEY = 'hubSubscriptionParams';
 
 class HubSubscription {
 
   constructor(form, subscriptionData, searchParams) {
     this._form = form;
     this._subscriptionData = subscriptionData;
-    let fragmentParams = new URLSearchParams(location.hash.substring(1));
-    this._subscriptionData.oldLicense = fragmentParams.get('oldLicense');
+    let restoredParams = this.resolveParams();
+    this._subscriptionData.oldLicense = restoredParams.oldLicense;
     if (this._subscriptionData.oldLicense) {
       try {
         let base64 = this._subscriptionData.oldLicense.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
@@ -24,9 +25,10 @@ class HubSubscription {
       }
     }
     this._subscriptionData.hubId = this._subscriptionData.hubId ?? searchParams.get('hub_id');
-    let returnUrl = fragmentParams.get('returnUrl') ?? searchParams.get('return_url');
+    let returnUrl = restoredParams.returnUrl ?? searchParams.get('return_url');
     if (returnUrl) {
       this._subscriptionData.returnUrl = returnUrl;
+      this._subscriptionData.returnUrlFromFragment = restoredParams.returnUrlFromFragment;
     }
     this._subscriptionData.session = searchParams.get('session');
     if (this._subscriptionData.hubId && this._subscriptionData.hubId.length > 0 && this._subscriptionData.returnUrl && this._subscriptionData.returnUrl.length > 0) {
@@ -44,6 +46,39 @@ class HubSubscription {
       window.Paddle.Setup({ vendor: PADDLE_VENDOR_ID });
       return window.Paddle;
     });
+  }
+
+  resolveParams() {
+    let fragmentParams = new URLSearchParams(location.hash.substring(1));
+    let oldLicense = fragmentParams.get('oldLicense');
+    let returnUrl = fragmentParams.get('returnUrl');
+    if (oldLicense || returnUrl) {
+      let params = { oldLicense: oldLicense, returnUrl: returnUrl, returnUrlFromFragment: returnUrl != null };
+      try {
+        sessionStorage.setItem(FRAGMENT_PARAMS_STORAGE_KEY, JSON.stringify(params));
+      } catch (e) {
+        console.error('Failed to persist hub billing parameters:', e);
+      }
+      // The oldLicense token is long enough that leaving it in the page URL breaks Paddle checkout, so we drop the fragment regardless of whether the stash succeeded.
+      history.replaceState(null, '', location.pathname + location.search);
+      return params;
+    }
+    let searchParams = new URLSearchParams(location.search);
+    let emptyParams = { oldLicense: null, returnUrl: null, returnUrlFromFragment: false };
+    try {
+      if (searchParams.has('hub_id') || searchParams.has('return_url')) {
+        // A fresh flow carries its own query params, so any stashed fragment from an earlier, abandoned flow is stale and must not override it.
+        sessionStorage.removeItem(FRAGMENT_PARAMS_STORAGE_KEY);
+        return emptyParams;
+      }
+      let stored = sessionStorage.getItem(FRAGMENT_PARAMS_STORAGE_KEY);
+      if (stored) {
+        return JSON.parse(stored);
+      }
+    } catch (e) {
+      console.error('Failed to restore hub billing parameters:', e);
+    }
+    return emptyParams;
   }
 
   loadSubscription() {
@@ -535,7 +570,13 @@ class HubSubscription {
   }
 
   transferTokenToHub() {
-    window.open(this._subscriptionData.returnUrl + '?token=' + this._subscriptionData.token, '_self');
+    try {
+      sessionStorage.removeItem(FRAGMENT_PARAMS_STORAGE_KEY);
+    } catch (e) {
+      console.error('Failed to clear hub billing parameters:', e);
+    }
+    let separator = this._subscriptionData.returnUrlFromFragment ? '#' : '?';
+    location.href = this._subscriptionData.returnUrl + separator + 'token=' + this._subscriptionData.token;
   }
 
 }

--- a/assets/js/hubsubscription.js
+++ b/assets/js/hubsubscription.js
@@ -7,6 +7,7 @@ const MANAGE_SUBSCRIPTION_URL = LEGACY_STORE_URL + '/hub/manage-subscription';
 const UPDATE_PAYMENT_METHOD_URL = LEGACY_STORE_URL + '/hub/update-payment-method';
 const REFRESH_LICENSE_URL = API_BASE_URL + '/licenses/hub/refresh';
 const FRAGMENT_PARAMS_STORAGE_KEY = 'hubSubscriptionParams';
+const EMPTY_PARAMS = { oldLicense: null, returnUrl: null, returnUrlFromFragment: false };
 
 class HubSubscription {
 
@@ -49,28 +50,54 @@ class HubSubscription {
   }
 
   resolveParams() {
+    let fragmentParams = this.parseFragmentParams();
+    if (fragmentParams) {
+      this.persistParams(fragmentParams);
+      return fragmentParams;
+    }
+    if (this.isFreshFlow()) {
+      // A fresh flow carries its own query params, so any stashed fragment from an earlier, abandoned flow is stale and must not override it.
+      this.clearPersistedParams();
+      return EMPTY_PARAMS;
+    }
+    return this.restorePersistedParams();
+  }
+
+  parseFragmentParams() {
     let fragmentParams = new URLSearchParams(location.hash.substring(1));
     let oldLicense = fragmentParams.get('oldLicense');
     let returnUrl = fragmentParams.get('returnUrl');
-    if (oldLicense || returnUrl) {
-      let params = { oldLicense: oldLicense, returnUrl: returnUrl, returnUrlFromFragment: returnUrl != null };
-      try {
-        sessionStorage.setItem(FRAGMENT_PARAMS_STORAGE_KEY, JSON.stringify(params));
-      } catch (e) {
-        console.error('Failed to persist hub billing parameters:', e);
-      }
-      // The oldLicense token is long enough that leaving it in the page URL breaks Paddle checkout, so we drop the fragment regardless of whether the stash succeeded.
-      history.replaceState(null, '', location.pathname + location.search);
-      return params;
+    if (!oldLicense && !returnUrl) {
+      return null;
     }
-    let searchParams = new URLSearchParams(location.search);
-    let emptyParams = { oldLicense: null, returnUrl: null, returnUrlFromFragment: false };
+    return { oldLicense: oldLicense, returnUrl: returnUrl, returnUrlFromFragment: returnUrl != null };
+  }
+
+  persistParams(params) {
     try {
-      if (searchParams.has('hub_id') || searchParams.has('return_url')) {
-        // A fresh flow carries its own query params, so any stashed fragment from an earlier, abandoned flow is stale and must not override it.
-        sessionStorage.removeItem(FRAGMENT_PARAMS_STORAGE_KEY);
-        return emptyParams;
-      }
+      sessionStorage.setItem(FRAGMENT_PARAMS_STORAGE_KEY, JSON.stringify(params));
+    } catch (e) {
+      console.error('Failed to persist hub billing parameters:', e);
+    }
+    // The oldLicense token is long enough that leaving it in the page URL breaks Paddle checkout, so we drop the fragment regardless of whether the stash succeeded.
+    history.replaceState(null, '', location.pathname + location.search);
+  }
+
+  isFreshFlow() {
+    let searchParams = new URLSearchParams(location.search);
+    return searchParams.has('hub_id') || searchParams.has('return_url');
+  }
+
+  clearPersistedParams() {
+    try {
+      sessionStorage.removeItem(FRAGMENT_PARAMS_STORAGE_KEY);
+    } catch (e) {
+      console.error('Failed to clear hub billing parameters:', e);
+    }
+  }
+
+  restorePersistedParams() {
+    try {
       let stored = sessionStorage.getItem(FRAGMENT_PARAMS_STORAGE_KEY);
       if (stored) {
         return JSON.parse(stored);
@@ -78,7 +105,7 @@ class HubSubscription {
     } catch (e) {
       console.error('Failed to restore hub billing parameters:', e);
     }
-    return emptyParams;
+    return EMPTY_PARAMS;
   }
 
   loadSubscription() {
@@ -570,13 +597,14 @@ class HubSubscription {
   }
 
   transferTokenToHub() {
-    try {
-      sessionStorage.removeItem(FRAGMENT_PARAMS_STORAGE_KEY);
-    } catch (e) {
-      console.error('Failed to clear hub billing parameters:', e);
+    this.clearPersistedParams();
+    let url = new URL(this._subscriptionData.returnUrl);
+    if (this._subscriptionData.returnUrlFromFragment) {
+      url.hash = 'token=' + encodeURIComponent(this._subscriptionData.token);
+    } else {
+      url.searchParams.set('token', this._subscriptionData.token);
     }
-    let separator = this._subscriptionData.returnUrlFromFragment ? '#' : '?';
-    location.href = this._subscriptionData.returnUrl + separator + 'token=' + this._subscriptionData.token;
+    location.href = url.href;
   }
 
 }

--- a/layouts/hub-billing/single.html
+++ b/layouts/hub-billing/single.html
@@ -3,7 +3,7 @@
 {{ end }}
 {{ define "main" }}
   <div class="container pt-12 pb-24">
-    <form x-data="{subscriptionData: {state: 'MISSING_PARAMS', captcha: null, hubId: null, returnUrl: null, session: null, oldLicense: null, customBilling: null, billingInterval: 'yearly', savingsPercent: null, errorMessage: '', inProgress: false, restartModal: {open: false, nextPayment: null}, changeSeatsModal: {open: false, confirmation: false, immediatePayment: null}, token: null, details: null, quantity: 5, email: '', needsTokenRefresh: false, shouldTransferToHub: false}, acceptTerms: false, hubSubscription: null, captchaState: null}" x-init="hubSubscription = new HubSubscription($refs.form, subscriptionData, new URLSearchParams(location.search))" x-ref="form" @submit.prevent="hubSubscription.createSession(); $refs.captcha.reset()">
+    <form x-data="{subscriptionData: {state: 'MISSING_PARAMS', captcha: null, hubId: null, returnUrl: null, returnUrlFromFragment: false, session: null, oldLicense: null, customBilling: null, billingInterval: 'yearly', savingsPercent: null, errorMessage: '', inProgress: false, restartModal: {open: false, nextPayment: null}, changeSeatsModal: {open: false, confirmation: false, immediatePayment: null}, token: null, details: null, quantity: 5, email: '', needsTokenRefresh: false, shouldTransferToHub: false}, acceptTerms: false, hubSubscription: null, captchaState: null}" x-init="hubSubscription = new HubSubscription($refs.form, subscriptionData, new URLSearchParams(location.search))" x-ref="form" @submit.prevent="hubSubscription.createSession(); $refs.captcha.reset()">
       <template x-if="subscriptionData.state == 'MISSING_PARAMS'">
         <div class="text-center max-w-xl mx-auto">
           <h3 class="font-headline text-xl md:text-2xl leading-relaxed mb-4">
@@ -354,7 +354,7 @@
                       {{ i18n "hub_billing_checkout_community_cta" . }}
                     </p>
                   </div>
-                  <a :href="`{{ "hub/register" | relLangURL }}#oldLicense=${encodeURIComponent(subscriptionData.oldLicense)}&returnUrl=${encodeURIComponent(subscriptionData.returnUrl)}`" role="button" class="btn btn-primary w-full">
+                  <a :href="`{{ "hub/register" | relLangURL }}#oldLicense=${encodeURIComponent(subscriptionData.oldLicense)}&returnUrl=${encodeURIComponent(subscriptionData.returnUrl)}&returnUrlFromFragment=${subscriptionData.returnUrlFromFragment}`" role="button" class="btn btn-primary w-full">
                     <i class="fa-solid fa-user-plus"></i>
                     {{ i18n "hub_billing_checkout_community_action" . }}
                   </a>

--- a/layouts/hub-register/single.html
+++ b/layouts/hub-register/single.html
@@ -2,7 +2,7 @@
   {{ partial "altcha-css.html" . }}
 {{ end }}
 {{ define "main" }}
-  <section x-data="{steps: ['{{ i18n "hub_ce_registration_step_1_nav_title" }}', '{{ i18n "hub_ce_registration_step_2_confirmation_nav_title" }}', '{{ i18n "hub_ce_registration_step_3_license_nav_title" }}'], feedbackData: {currentStep: 0, success: false, inProgress: false, errorMessage: '', licenseText: null, emailSent: false, emailVerified: false}, submitData: {captcha: null, oldLicense: '', email: '', acceptNewsletter: false}, acceptTerms: false, hubCE: null, captchaState: null, returnUrl: null}" x-init="const params = new URLSearchParams(location.hash.substring(1)); returnUrl = params.get('returnUrl'); hubCE = new HubCE($refs.form, feedbackData, submitData, params)" class="container py-12">
+  <section x-data="{steps: ['{{ i18n "hub_ce_registration_step_1_nav_title" }}', '{{ i18n "hub_ce_registration_step_2_confirmation_nav_title" }}', '{{ i18n "hub_ce_registration_step_3_license_nav_title" }}'], feedbackData: {currentStep: 0, success: false, inProgress: false, errorMessage: '', licenseText: null, emailSent: false, emailVerified: false}, submitData: {captcha: null, oldLicense: '', email: '', acceptNewsletter: false}, acceptTerms: false, hubCE: null, captchaState: null, returnUrl: null, returnUrlFromFragment: false}" x-init="const params = new URLSearchParams(location.hash.substring(1)); returnUrl = params.get('returnUrl'); returnUrlFromFragment = params.get('returnUrlFromFragment') === 'true'; hubCE = new HubCE($refs.form, feedbackData, submitData, params)" class="container py-12">
     <header class="mb-6">
       <h1 class="font-h1 mb-8">{{ .Title }}</h1>
       <p class="lead">{{ i18n "hub_ce_registration_description" }}</p>
@@ -188,7 +188,7 @@
                 <p class="font-p mb-4">{{ i18n "hub_ce_registration_step_3_success" }}</p>
                 <textarea class="block input-box w-full h-32 md:h-48 mb-8" x-text="feedbackData.licenseText" readonly></textarea>
                 <div class="mt-auto">
-                  <a :href="returnUrl + '?token=' + encodeURIComponent(feedbackData.licenseText)" class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-return-to-hub">
+                  <a :href="returnUrl + (returnUrlFromFragment ? '#' : '?') + 'token=' + encodeURIComponent(feedbackData.licenseText)" class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-return-to-hub">
                     <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
                     Todo: Return to Hub
                   </a>

--- a/layouts/hub-register/single.html
+++ b/layouts/hub-register/single.html
@@ -2,7 +2,7 @@
   {{ partial "altcha-css.html" . }}
 {{ end }}
 {{ define "main" }}
-  <section x-data="{steps: ['{{ i18n "hub_ce_registration_step_1_nav_title" }}', '{{ i18n "hub_ce_registration_step_2_confirmation_nav_title" }}', '{{ i18n "hub_ce_registration_step_3_license_nav_title" }}'], feedbackData: {currentStep: 0, success: false, inProgress: false, errorMessage: '', licenseText: null, emailSent: false, emailVerified: false}, submitData: {captcha: null, oldLicense: '', email: '', acceptNewsletter: false}, acceptTerms: false, hubCE: null, captchaState: null, returnUrl: null, returnUrlFromFragment: false}" x-init="const params = new URLSearchParams(location.hash.substring(1)); returnUrl = params.get('returnUrl'); returnUrlFromFragment = params.get('returnUrlFromFragment') === 'true'; hubCE = new HubCE($refs.form, feedbackData, submitData, params)" class="container py-12">
+  <section x-data="{steps: ['{{ i18n "hub_ce_registration_step_1_nav_title" }}', '{{ i18n "hub_ce_registration_step_2_confirmation_nav_title" }}', '{{ i18n "hub_ce_registration_step_3_license_nav_title" }}'], feedbackData: {currentStep: 0, success: false, inProgress: false, errorMessage: '', licenseText: null, emailSent: false, emailVerified: false}, submitData: {captcha: null, oldLicense: '', email: '', acceptNewsletter: false}, acceptTerms: false, hubCE: null, captchaState: null, returnUrl: null}" x-init="const params = new URLSearchParams(location.hash.substring(1)); returnUrl = params.get('returnUrl'); hubCE = new HubCE($refs.form, feedbackData, submitData, params)" class="container py-12">
     <header class="mb-6">
       <h1 class="font-h1 mb-8">{{ .Title }}</h1>
       <p class="lead">{{ i18n "hub_ce_registration_description" }}</p>
@@ -188,10 +188,12 @@
                 <p class="font-p mb-4">{{ i18n "hub_ce_registration_step_3_success" }}</p>
                 <textarea class="block input-box w-full h-32 md:h-48 mb-8" x-text="feedbackData.licenseText" readonly></textarea>
                 <div class="mt-auto">
-                  <a :href="returnUrl + (returnUrlFromFragment ? '#' : '?') + 'token=' + encodeURIComponent(feedbackData.licenseText)" class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-return-to-hub">
-                    <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
-                    Todo: Return to Hub
-                  </a>
+                  <template x-if="returnUrl">
+                    <a :href="hubCE.returnToHubUrl()" class="btn btn-primary w-full md:w-64" data-umami-event="hub-ce-registration-return-to-hub">
+                      <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
+                      Todo: Return to Hub
+                    </a>
+                  </template>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Hub license tokens are long enough to break URLs. Returning the refreshed license to the Hub instance as `?token=...` could push the query string past what servers accept, and the long inbound `#oldLicense` fragment sitting in the `/hub/billing/` page URL was enough to break Paddle checkout.

This keeps the token off the query string and out of the page URL:

- `transferTokenToHub` returns the license via the fragment (`#token=`) when `returnUrl` arrived via a fragment, falling back to `?token=` for query-sourced return URLs. Navigation uses `location.href` instead of `window.open(..., '_self')`.
- On load, `/hub/billing/` stashes the inbound fragment (`oldLicense`, `returnUrl`, `returnUrlFromFragment`) into `sessionStorage` and strips the hash, so the page URL stays short before Paddle opens. It rehydrates from `sessionStorage` on reload, but ignores and clears a stale stash when the query carries a fresh `hub_id`/`return_url`, so an abandoned flow can't bleed into a later one.
- The fragment-origin flag is carried through the `hub/register` community detour so that path returns the token on the same channel.

## Flow

```mermaid
sequenceDiagram
  Hub->>Billing: redirect with #oldLicense&returnUrl
  Billing->>sessionStorage: stash params
  Billing->>Billing: strip hash (replaceState)
  Billing->>Paddle: open checkout (short URL)
  Paddle-->>Billing: success + refreshed license
  Billing->>Hub: redirect returnUrl#token=
```
